### PR TITLE
Upgrade gradle to version 4.4

### DIFF
--- a/todoapp/gradle/wrapper/gradle-wrapper.properties
+++ b/todoapp/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Sep 07 17:20:52 BST 2016
+#Wed Jun 27 14:55:10 EDT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip


### PR DESCRIPTION
In order to work with Android Studio 3.1, we need to user gradle version 4.4