### PR TITLE
Update android.tools.build:gradle from 3.1.2 to 4.2.2

### DIFF
--- a/todoapp/build.gradle
+++ b/todoapp/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath "com.android.tools.build:gradle:4.2.2"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/todoapp/gradle/wrapper/gradle-wrapper.properties
+++ b/todoapp/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Sep 07 17:20:52 BST 2016
+#Sat Jul 03 22:59:35 IST 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
When running in Android Studio, the Gradle build tool uses Studio's bundled JDK. In previous releases, JDK 8 was bundled with Studio. In 4.2, however, JDK 11 is now bundled instead.

https://developer.android.com/studio/releases#android_gradle_plugin_420